### PR TITLE
Fix mask value

### DIFF
--- a/nanoid/method.py
+++ b/nanoid/method.py
@@ -7,7 +7,7 @@ from math import ceil, log
 def method(algorithm, alphabet, size):
     alphabet_len = len(alphabet)
 
-    mask = 2
+    mask = 1
     if alphabet_len > 1:
         mask = (2 << int(log(alphabet_len - 1) / log(2))) - 1
     step = int(ceil(1.6 * mask * size / alphabet_len))


### PR DESCRIPTION
When working with the library again, I came to a realization that mask indeed has to be 1 or calculated value otherwise.

Because when passing one letter to the mask, for example "a", mask has to be 1 but python does not support passing 0 to log.