### PR TITLE
chore(ci): Use github actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,34 @@
+name: ci
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  mypy:
+    name: Run tests and linting
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: ["linux", "win32", "darwin"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - run: uv pip install -r requirements.txt --system
+      - name: test
+        run: py.test test
+        continue-on-error: true
+      - name: lint
+        run: flake8 --max-line-length=99  nanoid test setup.py


### PR DESCRIPTION
Could use GHA instead of circleci—it's [free for public repos](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions)

Here, I've adapted [one from typeshed](https://github.com/python/typeshed/blob/main/.github/workflows/tests.yml) to run the two steps in the circleci runs, but on a matrix of all OSes and python versions